### PR TITLE
[DPLY-998] Replace rootProject with getParent utility function

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/Plugins.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/Plugins.kt
@@ -28,5 +28,5 @@ object Plugins {
   const val ADD_PLUGIN_DATA_TO_MANIFEST = "addPluginDataToManifest"
 
   internal fun hasDeckPlugin(project: Project): Boolean =
-    project.rootProject.subprojects.any { it.plugins.hasPlugin(SpinnakerUIExtensionPlugin::class.java) }
+    getParent(project).subprojects.any { it.plugins.hasPlugin(SpinnakerUIExtensionPlugin::class.java) }
 }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/ProjectHelper.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/ProjectHelper.kt
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.gradle.extension
+
+import org.gradle.api.Project
+
+fun getParent(project: Project): Project = project.parent ?: project.rootProject

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -55,7 +55,7 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     val pluginExt = project.extensions.findByType(SpinnakerPluginExtension::class.java)
       ?: throw IllegalStateException("A 'spinnakerPlugin' configuration block is required")
 
-    val bundleExt = project.rootProject.extensions.findByType(SpinnakerBundleExtension::class.java)
+    val bundleExt = getParent(project).extensions.findByType(SpinnakerBundleExtension::class.java)
       ?: throw IllegalStateException("A 'spinnakerBundle' configuration block is required")
 
     val attributes = mutableMapOf<String, String>()
@@ -107,7 +107,7 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
 
   //the plugin version is supplied with a v from tag, but fails when update manager compares versions
   private fun removeTagPrefix(bundleVersion: String, project: Project): String {
-    val version = if (isVersionSpecified(bundleVersion)) bundleVersion else project.rootProject.version.toString()
+    val version = if (isVersionSpecified(bundleVersion)) bundleVersion else getParent(project).version.toString()
     return version.removePrefix("v")
   }
 

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.gradle.extension.compatibility.CompatibilityTestRes
 import com.netflix.spinnaker.gradle.extension.compatibility.CompatibilityTestTask
 import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerBundleExtension
 import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerPluginExtension
+import com.netflix.spinnaker.gradle.extension.getParent
 import groovy.json.JsonOutput
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -41,16 +42,16 @@ open class CreatePluginInfoTask : DefaultTask() {
   override fun getGroup(): String = Plugins.GROUP
 
   @Internal
-  val rootProjectVersion: String = project.rootProject.version.toString()
+  val rootProjectVersion: String = getParent(project).version.toString()
 
   @TaskAction
   fun doAction() {
-    val allPluginExts = project.rootProject
+    val allPluginExts = getParent(project)
       .subprojects
       .mapNotNull { it.extensions.findByType(SpinnakerPluginExtension::class.java) }
       .toMutableList()
 
-    val bundleExt = project.rootProject.extensions.findByType(SpinnakerBundleExtension::class.java)
+    val bundleExt = getParent(project).extensions.findByType(SpinnakerBundleExtension::class.java)
       ?: throw IllegalStateException("A 'spinnakerBundle' configuration block is required")
 
     val requires = allPluginExts.map { it.requires ?: "${it.serviceName}>=0.0.0" }
@@ -63,7 +64,7 @@ open class CreatePluginInfoTask : DefaultTask() {
       }
       .joinToString(",")
 
-    val compatibility = project.rootProject
+    val compatibility = getParent(project)
       .subprojects
       .flatMap { it.tasks.withType(CompatibilityTestTask::class.java) }
       .map { it.result.get().asFile }
@@ -97,7 +98,7 @@ open class CreatePluginInfoTask : DefaultTask() {
   }
 
   private fun getChecksum(): String {
-    return project.rootProject.tasks
+    return getParent(project).tasks
       .getByName(CHECKSUM_BUNDLE_TASK_NAME)
       .outputs
       .files


### PR DESCRIPTION
The Spinnaker extensions were using `project.rootProject` to get the bundle extension information.

An example of the current required project structure.

```
rootProject (plugin: io.spinnaker.plugin.bundler)
|-- deck (plugin: io.spinnaker.plugin.ui-extension)
|-- orca (plugin: io.spinnaker.plugin.service-extension)
```

By changing the reference to be either `project.parent` or default back to `project.rootProject` we allow ourselves to create more nested projects.

```
rootProject (plugin: none)
|--plugins
|  |--plugin1 (plugin: io.spinnaker.plugin.bundler)
|  |  |-- deck (plugin: io.spinnaker.plugin.ui-extension)
|  |  |-- orca (plugin: io.spinnaker.plugin.service-extension)
|  |--plugin2 (plugin: io.spinnaker.plugin.bundler)
|  |  |-- deck (plugin: io.spinnaker.plugin.ui-extension)
|  |  |-- orca (plugin: io.spinnaker.plugin.service-extension)
```

or however deep you wanna go. The requirements are now just that the ui and service extensions just need to be underneath a project (could be a subproject) that has the bundler plugin applied.