### PR TITLE
Update readme and fix checksum bug

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
@@ -42,16 +42,16 @@ open class CreatePluginInfoTask : DefaultTask() {
   override fun getGroup(): String = Plugins.GROUP
 
   @Internal
-  val rootProjectVersion: String = getParent(project).version.toString()
+  val rootProjectVersion: String = project.version.toString()
 
   @TaskAction
   fun doAction() {
-    val allPluginExts = getParent(project)
+    val allPluginExts = project
       .subprojects
       .mapNotNull { it.extensions.findByType(SpinnakerPluginExtension::class.java) }
       .toMutableList()
 
-    val bundleExt = getParent(project).extensions.findByType(SpinnakerBundleExtension::class.java)
+    val bundleExt = project.extensions.findByType(SpinnakerBundleExtension::class.java)
       ?: throw IllegalStateException("A 'spinnakerBundle' configuration block is required")
 
     val requires = allPluginExts.map { it.requires ?: "${it.serviceName}>=0.0.0" }
@@ -64,7 +64,7 @@ open class CreatePluginInfoTask : DefaultTask() {
       }
       .joinToString(",")
 
-    val compatibility = getParent(project)
+    val compatibility = project
       .subprojects
       .flatMap { it.tasks.withType(CompatibilityTestTask::class.java) }
       .map { it.result.get().asFile }
@@ -98,7 +98,7 @@ open class CreatePluginInfoTask : DefaultTask() {
   }
 
   private fun getChecksum(): String {
-    return getParent(project).tasks
+    return project.tasks
       .getByName(CHECKSUM_BUNDLE_TASK_NAME)
       .outputs
       .files


### PR DESCRIPTION
I've revamped the readme to be a bit more detailed on how to use the plugins and what a project structure must look like.

Also updated the `CreatePluginInfoTask` to reference the current project instead of the rootproject. The task is only ever applied to the same project that the bundle plugin is applied. So we can reference the current project instead of the parent or the root.